### PR TITLE
bug fixes and avoiding deprecation warnings

### DIFF
--- a/Data_Generator.py
+++ b/Data_Generator.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import torch
 from torch.utils.data import Dataset
 import numpy as np

--- a/Train.py
+++ b/Train.py
@@ -1,9 +1,9 @@
-"""
+#!/usr/bin/env python3
 
+"""
 Pytorch implementation of Pointer Network.
 
 http://arxiv.org/pdf/1506.03134v1.pdf.
-
 """
 
 import torch
@@ -95,13 +95,13 @@ for epoch in range(params.nof_epoch):
 
         loss = CCE(o, target_batch)
 
-        losses.append(loss.data[0])
-        batch_loss.append(loss.data[0])
+        losses.append(loss.item())
+        batch_loss.append(loss.item())
 
         model_optim.zero_grad()
         loss.backward()
         model_optim.step()
 
-        iterator.set_postfix(loss='{}'.format(loss.data[0]))
+        iterator.set_postfix(loss='{}'.format(loss.item()))
 
     iterator.set_postfix(loss=np.average(batch_loss))


### PR DESCRIPTION
Running Train.py with Python 3.6 and Pytorch 1.0.1 results in several deprecation warnings due to API changes, and eventually crashes with a TypeError (see below). This commit updates the code to Python 3.6 and Pytorch 1.0.1. Afterwards, it runs without any warnings or other problems.


Warnings:

PointerNet/PointerNet.py:105: UserWarning: nn.init.uniform is now deprecated in favor of nn.init.uniform_.
  nn.init.uniform(self.V, -1, 1)
PointerNet/PointerNet.py:290: UserWarning: nn.init.uniform is now deprecated in favor of nn.init.uniform_.
  nn.init.uniform(self.decoder_input0, -1, 1)


Trace of crash:
  
  ...
  File "PointerNet/PointerNet.py", line 312, in forward
    decoder_hidden0 = (torch.cat(encoder_hidden[0][-2:], dim=-1),
TypeError: cat(): argument 'tensors' (position 1) must be tuple of Tensors, not Tensor